### PR TITLE
Fix non-english characters in Spark Messages

### DIFF
--- a/src/CiscoSpark.js
+++ b/src/CiscoSpark.js
@@ -1,6 +1,9 @@
 'use strict'
 
 /** @ignore */
+const fixString = text => escape(text).replace(/%(..)/g, '&#x$1;')
+
+/** @ignore */
 const request = require('request')
 
 /**
@@ -114,7 +117,11 @@ class CiscoSpark {
     if (!args.params) return callback(new Error('Invalid Params.'))
     this.request({
       method: 'POST',
-      form: args.params
+      form: Object.assign(args.params, {
+        markdown: fixString(args.params.markdown || ''),
+        text: fixString(args.params.text || ''),
+        html: fixString(args.params.html || '')
+      })
     }, args.callback)
   }
 

--- a/test/messages-spec.js
+++ b/test/messages-spec.js
@@ -9,6 +9,8 @@ const TEST_ACCESSTOKEN = '**TestAccessToken**'
 const TEST_USERAGENT = '**TestUsergent**'
 const TEST_ROOM_ID = '**TestRoomId**'
 
+const fixString = text => escape(text).replace(/%(..)/g, '&#x$1;')
+
 /** @test {Messages} */
 describe('CiscoSpark.messages', function () {
   before(function () {
@@ -32,7 +34,7 @@ describe('CiscoSpark.messages', function () {
         expect(response.options.headers['User-Agent']).to.be.equal(TEST_USERAGENT)
         expect(response.options.method).to.be.equal('POST')
         expect(response.options.form.roomId).to.be.equal(TEST_ROOM_ID)
-        expect(response.options.form.markdown).to.be.equal(text)
+        expect(response.options.form.markdown).to.be.equal(fixString(text))
         done()
       })
     })
@@ -78,7 +80,7 @@ describe('CiscoSpark.messages', function () {
         expect(err).to.be.not.ok
         expect(response.options.method).to.be.equal('POST')
         expect(response.options.form.toPersonId).to.be.equal(TEST_ID)
-        expect(response.options.form.markdown).to.be.equal(text)
+        expect(response.options.form.markdown).to.be.equal(fixString(text))
         done()
       })
     })
@@ -91,7 +93,7 @@ describe('CiscoSpark.messages', function () {
         expect(err).to.be.not.ok
         expect(response.options.method).to.be.equal('POST')
         expect(response.options.form.toPersonEmail).to.be.equal(TEST_ID)
-        expect(response.options.form.markdown).to.be.equal(text)
+        expect(response.options.form.markdown).to.be.equal(fixString(text))
         done()
       })
     })


### PR DESCRIPTION
Updated HTTP GET code and tests to correctly escape characters, making it suitable to send non-english characters.
There may be something wrong with this approach, as I'm not sure if the "text" key should also be escaped.